### PR TITLE
support custom gulp filename other than gulpfile.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var fs = require('graceful-fs'),
 
 module.exports = function(gulp) {
     gulp.task('task-list', function() {
-        var gulpfileCode = fs.readFileSync('gulpfile.js').toString(),
+        var gulpfileCode = fs.readFileSync(/[^\\/]+$/.exec(__filename)[0]).toString(),
             table = new clitable({
                 head: ['Task name', 'Description', 'Dependencies'],
                 chars: {


### PR DESCRIPTION
#### allow reading from different gulp config files

As an example, having a `Gulpfile.js` would fail because the `G` is capitalized and then `gulpfile.js` is not found. This process ensure that we read the file that we execute it from.

`__filename` is always defined unless you run node from the CLI directly

fixes #12 
