### PR TITLE
Fix issue with Descriptions retrieval.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(gulp, ignoreTasks) {
               continue;
             }
             if (gulp.tasks.hasOwnProperty(taskName)) {
-                start = gulpfileCode.lastIndexOf("//", gulpfileCode.indexOf(gulp.tasks[taskName].fn.toString()));
+                start = gulpfileCode.lastIndexOf("//", gulpfileCode.indexOf(taskName));
                 end = gulpfileCode.indexOf('\n', start);
                 if (start !== -1 && end !== -1) {
                     start += 2;


### PR DESCRIPTION
Change comment's start index search reference from task's function string to task's name

Fix an issue with incorrect index retrieval that prevented Descriptions from being printed to the console.